### PR TITLE
Better match Material Design spec.

### DIFF
--- a/core-tooltip.css
+++ b/core-tooltip.css
@@ -27,10 +27,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 .core-tooltip {
   position: absolute;
   font-size: 10px;
-  font-family: sans-serif;
+  font-weight: 500;
   padding: 8px;
   color: white;
-  background-color: rgba(0,0,0,0.8);
+  background-color: rgba(0, 0, 0, 0.9);
   box-sizing: border-box;
   border-radius: 3px; /* TODO: not in spec. */
   white-space: nowrap;


### PR DESCRIPTION
Use Medium weight font, and the background alpha given in the spec. Also allow the font-family to be inherited, so that Roboto can be used without any shadow DOM styling.
